### PR TITLE
Adding Freedom Beans page

### DIFF
--- a/freedom-beans.md
+++ b/freedom-beans.md
@@ -1,0 +1,125 @@
+---
+title: Freedom Beans
+slug: freedom-beans
+top_image: ''
+description: >-
+  From a prison pocket to a thriving garden: beans that carry stories of 
+  resilience, freedom, and new beginnings. Become a part of a 
+  rebellious network sowing hope, healing, and connection.
+image: /uploads/RIPS-square.jpeg
+layout: page
+---
+
+# Freedom Beans
+
+From a prison pocket to a thriving garden: beans that carry stories of resilience, freedom, and new beginnings. Become
+a part of a rebellious network sowing hope, healing, and connection.
+
+### Calling all!
+
+We want to share something small but powerful with you – <strong>Freedom Beans!</strong>
+
+One of our incredible rebels, Cressie (WTF), planted beans while in HMP Send. The kitchen would have rejected the small, gnarly ones, and they would have been  thrown away, so - instinctively - she kept them. After her release, she planted them in her garden, and 18 beautiful bean plants have grown.
+
+This autumn, we’ll have an abundance of beans ready to share. They’re not just any beans - they carry a story of resilience, hope, liberation and regeneration. Grown in captivity, nurtured in freedom, and now offered as tiny symbols of survival and new beginnings - of building something new from the cracks in the old.
+
+### Join the movement
+
+If you’d like to receive some Prison Beans to plant - wherever you are – please let us know at [rebelsinprison@gmail.com](mailto:rebelsinprison@gmail.com "rebelsinprison@gmail.com"). Whether on a windowsill, in a pot, or out in the soil, you’ll be part of a living network growing food, hope, healing and connection from a place that tried to take it away. 
+
+We are hoping this will spark opportunities for people to have bean parties & socials - cooking and eating together with home-grown beans. Sharing bean recipes, making music (maracas, rain sticks) with dried beans that can’t germinate - creating seed art or mosaics, hosting storytelling circles, community meals, gardening sessions, or bean swaps!
+
+### One bean at a time
+
+There’s no set way to do this - we won’t be “policing” bean parties! Play, imagine, and reclaim joy in whatever way feels good.
+
+This isn’t just a gardening project - it’s about planting the idea that another world is possible - one bean at a time!
+
+If you would like to support the wider work of RIPS you’re welcome to [offer an optional donation](/donate/). Every contribution helps us continue the work we do, and grow our community of care, supporting people through and beyond prison, and helping beautiful projects like Prison Beans take root and thrive.
+
+### “We Were Never Meant to Grow”
+
+A short story from a Prison Bean.
+
+<small>*They called me small. No good.<br>
+Unfit for the kitchen.<br>
+They tossed me aside - too twisted to be useful.*</small>
+
+<small>*But she saw me.<br>
+She tucked me into her pocket, smuggled me past fences, and whispered,<br>
+“Not yet. Your time will come.”*</small>
+
+<small>*I was born behind prison walls.<br>
+Rooted in silence, watered by sorrow.<br>
+I slept in the dark, dreaming of sky.*</small>
+
+<small>*When she walked free, she took me with her.<br>
+And in the soft soil of her garden, I stretched.<br>
+I reached for the sun like I’d never been caged.*</small>
+
+<small>*Now my brothers and sisters are ready.<br>
+We are not just seeds - we are stories.<br>
+Stories of resilience...<br>
+Of roots breaking through concrete.<br>
+Of freedom that grows, regardless.*</small>
+
+<small>*We want to travel - to your windowsills, allotments, balconies and fields.<br>
+We want to whisper abolition as we climb,<br>
+To rustle with resistance in the wind.*</small>
+
+<small>*We were never meant to grow.<br>
+But we did.<br>
+And now we carry the future in our pods.*</small>
+
+### The Story of Cressie's Beans
+
+These beans lived inside a prison. They are alive today because imprisoned people gave their
+attention to growing them.
+
+In a polytunnel in HMP Send, they were planted by prisoners, tended by prisoners, watered by
+prisoners. Most of the beans themselves went to the prison kitchens, to be cooked by prisoners.
+Eventually, they were eaten by prisoners.
+
+When the beans had finished fruiting, the plants were pulled out by prisoners. But there were a
+few pods still left on the plant, beans which had grown too big and tough to be sent to the kitchens.
+Instinctively, one prisoner pocketed the overgrown pods, before the plants were dumped on the
+compost.
+
+She hid them in her socks to leave the gardens. And back in her cell, she carefully laid them out to
+dry.
+
+6 months later, the prisoner was released. In amongst the books and the clothes and the
+paperwork and the other stuff accumulated throughout her incarceration, she found a little plastic
+pot with beans inside.
+
+They were asking to be planted.
+
+No longer inside the prison walls, the beans felt their liberation. They germinated fast, and grew
+strong and healthy. In prison, they had been dwarf beans, but outside they quickly grew to the
+height of climbing beans. Everything about them cried out joyfully in their newfound freedom.
+
+If only prisoners had the same experience. If only the end to their physical incarceration was true
+liberation. But the outside world can be just as much of a prison as the institution behind bars. So
+many prisoners do not have the means or the opportunity to flourish like these beans when they
+are released.
+
+One bean grows into a plant which gives the gift of hundreds of edible beans, and enough seeds to
+grow a hundred more. The prison-like grip of capitalism constructs an environment of false
+scarcity, to work us to the bone to earn enough money to buy enough to eat. The prison-like grip
+of military occupations forcibly withholds food and starves an entire people. And all the while,
+there are beans which multiply by the hundred without any money and very little labour. They
+know no borders, they make no judgements. These gifts are for sharing, to nourish one another in
+a society which rarely nourishes us.
+
+We are interconnected. And we can hope that the growing of beans may go some small way to
+meeting the lack of true liberation for prison-leavers. In spirit, through the tending and nurturing,
+and the bean gifts received in return. And practically, with the body-nourishing vitamins, protein
+and fibre that grow on every stem. After doing time, where the body is stressed, and starved of
+many essential nutrients, the importance of good food which is shared freely must not be
+underestimated.
+
+These beans call out loud and clear that they are offering us an abundance to be shared – with
+prisoners, with refugees, with anyone and everyone who is ground down by the uncare and state
+violence. In one way or another that is all of us. Let us accept and share these gifts with gratitude
+and humility. In doing so, let us consciously connect with one another as fellow plant tenders, and
+fellow human beings who yearn for a life-sustaining society.


### PR DESCRIPTION
Adding the Freedom Beans page. This is the first iteration of the page, pending feedback. I have no access to Tina CMS, so the content of the page has been hard-coded.

Please note: the solution has been tested manually by running `bundle exec jekyll serve`. A manual test by another person would be welcome to verify the changes are non-breaking.

Additionally, when running `bundle install` the Gemfile.lock has been touched, and a bunch of minor versions have been upgraded, as well as a bunch of dependencies have been added. I am not including this change in the PR, as I don't see how the addition of the new page with trivial content would require a dependencies update.

<img width="2533" height="1210" alt="Zrzut ekranu 2025-08-31 220139" src="https://github.com/user-attachments/assets/2d550af3-a153-4ff7-a2cc-b28e427b8818" />
