### PR TITLE
Bugfix: rebels' displayed current prison not up-to-date

### DIFF
--- a/_layouts/rebel.html
+++ b/_layouts/rebel.html
@@ -83,7 +83,7 @@ layout: page
 <h2>Stretches in prison</h2>
 <ul>
   {% for sentence in page.sentences %}
-    {% assign prison = sentence.prison | first %}
+    {% assign prison = sentence.prison | last %}
     <li>
       {{ sentence.duration }} days at <a href="{{ prison.url }}">{{ prison.title }}</a>.
     </li>


### PR DESCRIPTION
Bugfix: rebels' displayed current prison not up-to-date, e.g.:

<img width="578" height="328" alt="Zrzut ekranu 2026-01-19 223744" src="https://github.com/user-attachments/assets/7fda5916-563d-4e92-8f35-8a3afad79e1f" />
<img width="477" height="403" alt="Zrzut ekranu 2026-01-19 223831" src="https://github.com/user-attachments/assets/a5c54ab8-56a4-46af-ae93-7f8b14600d5c" />
